### PR TITLE
refactor(spark): remove --parallel flag and reorder transformations

### DIFF
--- a/k8s/spark-streaming.yaml
+++ b/k8s/spark-streaming.yaml
@@ -187,7 +187,6 @@ spec:
             - --conf
             - "spark.hadoop.fs.s3a.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
             - /app/etl_bronze_to_silver.py
-            - --parallel
             env:
             - name: MINIO_ENDPOINT
               value: "minio-service:9000"

--- a/setup_and_deploy_api.sh
+++ b/setup_and_deploy_api.sh
@@ -466,7 +466,7 @@ kubectl create configmap dbt-models \
 # Create dbt project files ConfigMap
 kubectl create configmap dbt-project-config \
     --from-file=dbt/dbt_project.yml \
-    --from-file=dbt/requirements.txt \
+    --from-file=requirements.txt=dbt/requirements_duckdb.txt \
     -n $NAMESPACE \
     --dry-run=client -o yaml | kubectl apply -f -
 

--- a/spark/etl_bronze_to_silver.py
+++ b/spark/etl_bronze_to_silver.py
@@ -569,11 +569,11 @@ class BronzeToSilverETL:
         
         try:
             # Transform all data sources sequentially
-            self.transform_acra_companies()
             self.transform_singstat_economics()
             self.transform_ura_geospatial()
             self.transform_commercial_rental_index()
             self.transform_government_expenditure()
+            self.transform_acra_companies()
             
             logger.info("Bronze to Silver ETL completed successfully")
             


### PR DESCRIPTION
- Remove deprecated --parallel flag from spark-streaming job
- Update dbt requirements file reference in deployment script
- Reorder ETL transformations for better execution flow